### PR TITLE
Make get/remove content public.

### DIFF
--- a/src/main/java/org/fxmisc/flowless/VirtualizedScrollPane.java
+++ b/src/main/java/org/fxmisc/flowless/VirtualizedScrollPane.java
@@ -91,10 +91,18 @@ public class VirtualizedScrollPane<V extends Node & Virtualized> extends Region 
     }
 
     /**
+     * Does not unbind scrolling from Content before returning Content.
+     * @return - the content
+     */
+    public V getContent() {
+        return content;
+    }
+
+    /**
      * Unbinds scrolling from Content before returning Content.
      * @return - the content
      */
-    V removeContent() {
+    public V removeContent() {
         getChildren().clear();
         return content;
     }


### PR DESCRIPTION
Besides this, should there be a "setContent()" method? Then VirtualizedScrollPane could be a reusable object. Otherwise, user has to recreate a new object every time they want to change its content.